### PR TITLE
2.5.1: Fix gelbooru parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
 .idea/
 
+### Gradle ###
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+
 # Compiled class file
 *.class
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 import org.apache.tools.ant.filters.ReplaceTokens
-def versionObj = new Version(major: 2, minor: 5, revision: 0)
+def versionObj = new Version(major: 2, minor: 5, revision: 1)
 
 group 'net.kodehawa'
 version "$versionObj"

--- a/src/main/java/net/kodehawa/lib/imageboards/boards/DefaultBoards.java
+++ b/src/main/java/net/kodehawa/lib/imageboards/boards/DefaultBoards.java
@@ -36,7 +36,7 @@ public enum DefaultBoards implements Board {
     YANDERE("https", "yande.re", "post.json", null, "page"),
     DANBOORU("https", "danbooru.donmai.us", "posts.json", null, "page"),
     SAFEBOORU("https", "safebooru.org", "index.php", "page=dapi&s=post&q=index&json=1", "pid"),
-    GELBOORU("https", "gelbooru.com", "index.php", "page=dapi&s=post&q=index&json=1", "pid"),
+    GELBOORU("https", "gelbooru.com", "index.php", "page=dapi&s=post&q=index&json=1", "pid", "post"),
     E926("https", "e926.net", "posts.json", null, "page", "posts");
 
     private final String scheme;

--- a/src/main/java/net/kodehawa/lib/imageboards/entities/Rating.java
+++ b/src/main/java/net/kodehawa/lib/imageboards/entities/Rating.java
@@ -17,24 +17,24 @@
 package net.kodehawa.lib.imageboards.entities;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Board image ratings. Just remember that God is watching.
+ *
  * @author Avarel
  */
+@JsonDeserialize(using = RatingDeserializer.class)
 public enum Rating {
     /**
      * Safe for family and friends. If you had any.
      */
-    @JsonProperty("s")
     SAFE("s"),
 
     /**
      * Questionable board images. Borderline explicit.
      * Would you show this to your grandma?
      */
-    @JsonProperty("q")
     QUESTIONABLE("q"),
 
     /**
@@ -43,7 +43,6 @@ public enum Rating {
      * Dirty af. Go see a therapist.
      */
     @JsonEnumDefaultValue
-    @JsonProperty("e")
     EXPLICIT("e");
 
     String shortName, longName;
@@ -68,8 +67,8 @@ public enum Rating {
      * @return The badge, or null if nothing is found.
      */
     public static Rating lookupFromString(String name) {
-        for(Rating b : Rating.values()) {
-            if(b.name().equalsIgnoreCase(name)) {
+        for (Rating b : Rating.values()) {
+            if (b.name().equalsIgnoreCase(name)) {
                 return b;
             }
         }
@@ -83,8 +82,8 @@ public enum Rating {
      * @return The badge, or null if nothing is found.
      */
     public static Rating lookupFromStringShort(String shortName) {
-        for(Rating b : Rating.values()) {
-            if(b.getShortName().equalsIgnoreCase(shortName)) {
+        for (Rating b : Rating.values()) {
+            if (b.getShortName().equalsIgnoreCase(shortName)) {
                 return b;
             }
         }

--- a/src/main/java/net/kodehawa/lib/imageboards/entities/RatingDeserializer.java
+++ b/src/main/java/net/kodehawa/lib/imageboards/entities/RatingDeserializer.java
@@ -1,0 +1,26 @@
+package net.kodehawa.lib.imageboards.entities;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+
+public class RatingDeserializer extends JsonDeserializer<Rating> {
+
+    @Override
+    public Rating deserialize(JsonParser parser, DeserializationContext ctx)
+            throws IOException {
+        String value = parser.getValueAsString();
+        Rating rating = Rating.lookupFromStringShort(value);
+        if (rating != null) {
+            return rating;
+        }
+        rating = Rating.lookupFromString(value);
+        if (rating != null) {
+            return rating;
+        }
+        throw new IOException("Unable to deserialize rating " + value);
+    }
+
+}


### PR DESCRIPTION
Looks like gelbooru updated their API and now posts are inside a JSON Object instead of directly being in a JSON array. This was causing a deserialization error in Jackson. 

```diff
- [{
+ {"@attributes":{"limit":100,"offset":0,"count":6458277},"post":[{
```

I added the `outerObject` property to the imageboard to fix this. It then started to error when trying to parse the rating flags as it seems they also changed it from `[s, q, e]` to `[safe, questionable, explicit]`. Since there wasn't any mechanism already present for using these long names instead of the short identifiers, I created a JsonDeserializer for the rating enum that takes into account both.

I bumped as a revision update, not sure if this is correct. I also added some missing gradle folders to gitignore.